### PR TITLE
Moved github access token to headers

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -21,16 +21,17 @@ import (
 //DownloadFileToString downloads a file from a given URL and returns it's
 //contents as a string if successful
 func DownloadFileToString(url string) (string, error) {
-
-	// fmt.Println("Downloading ", url)
-
 	var client http.Client
-	resp, err := client.Get(url + "?access_token=" + appConf.GithubToken)
+    req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-
+    req.Header.Add("Authorization", "token " + appConf.GithubToken)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+    defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -38,7 +39,6 @@ func DownloadFileToString(url string) (string, error) {
 		}
 		return string(bodyBytes), nil
 	}
-
 	return "", err
 }
 


### PR DESCRIPTION
Authentication on Github using query parameters will be removed and I have
therefore moved them to the headers.
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/
This fixes issue #36.