### PR TITLE
Fix tests and downloads from GitHub

### DIFF
--- a/colorscheme_test.go
+++ b/colorscheme_test.go
@@ -102,7 +102,25 @@ func TestBase16ColorschemeList_GetBase16Colorscheme(t *testing.T) {
 }
 
 func TestNewBase16Colorscheme(t *testing.T) {
-	data1, _ := DownloadFileToString("https://raw.githubusercontent.com/atelierbram/base16-atelier-schemes/master/atelier-forest.yaml")
+	data1 := `scheme: "Atelier Forest"
+author: "Bram de Haan (http://atelierbramdehaan.nl)"
+base00: "1b1918"
+base01: "2c2421"
+base02: "68615e"
+base03: "766e6b"
+base04: "9c9491"
+base05: "a8a19f"
+base06: "e6e2e0"
+base07: "f1efee"
+base08: "f22c40"
+base09: "df5320"
+base0A: "c38418"
+base0B: "7b9726"
+base0C: "3d97b8"
+base0D: "407ee7"
+base0E: "6666ea"
+base0F: "c33ff3"`
+
 	want1 := Base16Colorscheme{
 		Name:       "Atelier Forest",
 		Author:     "Bram de Haan (http://atelierbramdehaan.nl)",

--- a/helpers.go
+++ b/helpers.go
@@ -38,6 +38,8 @@ func DownloadFileToString(url string) (string, error) {
 			return "", err
 		}
 		return string(bodyBytes), nil
+	} else if err == nil {
+		err = fmt.Errorf("HTTP code %v", resp.StatusCode)
 	}
 	return "", err
 }

--- a/helpers.go
+++ b/helpers.go
@@ -81,7 +81,7 @@ func findYAMLinRepo(repoURL string) []GitHubFile {
 	// Create a list of .yaml files
 	var colorSchemes []GitHubFile
 	for _, v := range keys {
-		re := regexp.MustCompile(".*yaml")
+		re := regexp.MustCompile(".*ya?ml")
 		if re.MatchString(v.Name) {
 			colorSchemes = append(colorSchemes, v)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -21,6 +21,7 @@ func TestBase16Render(t *testing.T) {
 	type args struct {
 		templ  Base16Template
 		scheme Base16Colorscheme
+		app string
 	}
 	tests := []struct {
 		name string
@@ -30,7 +31,7 @@ func TestBase16Render(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			Base16Render(tt.args.templ, tt.args.scheme)
+			Base16Render(tt.args.templ, tt.args.scheme, tt.args.app)
 		})
 	}
 }


### PR DESCRIPTION
GitHub appears to now return a 404 when no GithubToken is specified.
Instead of failing to retrieve and having empty templates or repo lists,
return an error message to the user by propagating the HTTP error code.