### PR TITLE
Add fish shell completions: options & all themes autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ go build
 
 If you get errors on missing dependencies, install them as usual with `go get`.
 
+### Shell completions
+* [fish shell](https://github.com/fish-shell/fish-shell) completions: Add the [`completions/fish/base16-universal-manager.fish`](completions/fish/base16-universal-manager.fish) to `~/.config/fish/completions/`
+
+      wget https://raw.githubusercontent.com/pinpox/base16-universal-manager/master/completions/fish/base16-universal-manager.fish -O ~/.config/fish/completions/base16-universal-manager.fish
+
 ## Usage
 
 To run, just execute the application without any command line flags. It will

--- a/completions/fish/base16-universal-manager.fish
+++ b/completions/fish/base16-universal-manager.fish
@@ -1,0 +1,17 @@
+# Fish completions for base16-universal-manager
+
+# Never complete with filenames
+complete -f -c base16-universal-manager -d "A command line tool to install base16 templates and set themes globally"
+
+# Complete available themes
+set -l themes_list (sed -n 's/^\(.*\).yaml:.*/\1/p' ~/.cache/base16-universal-manager/schemeslist.yaml)
+complete -f -c base16-universal-manager -n "__fish_seen_subcommand_from --scheme; and test (count (commandline -opc)) -eq 2" -a "$themes_list"
+
+# Description for each command
+set -l base16_universal_manager_commands (base16-universal-manager --help-long | sed -En 's/^  (--(\w-?)+).*/\1/p')
+set -l base16_universal_manager_commands_help (base16-universal-manager --help-long | sed 1,3d | sed -En 's/.{21}([A-Z].*)/\1/p')
+set -l i 1
+for command in $base16_universal_manager_commands
+    complete -f -c base16-universal-manager -n "not __fish_seen_subcommand_from $base16_universal_manager_commands" -a "$command" -d "$base16_universal_manager_commands_help[$i]"
+    set -l i (math $i + 1)
+end


### PR DESCRIPTION
Add option and theme completions for the fish shell https://github.com/fish-shell/fish-shell

base16-manager had an option to display available themes. It's a nice feature to try out new themes while not having to search online for their names.

Example of the result:

https://user-images.githubusercontent.com/54000402/108609906-29b0b780-73c9-11eb-9282-b4435e1c48c2.mp4

