### PR TITLE
Revert "Support local scheme file."

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,9 @@ consists mainly of two parts:
 | DryRun |  false | Print the rendered files to stdout instead of saving them|
 
 The provided theme names, do not have to be exact.
-The [Levenstein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)
+The [Levenstein distance](https://en.wikipedia.org/wiki/Levenshtein_distance<Paste>)
 is used to calculate the best matching option. This is handy in case you only
 partly remember the name of a particular scheme, if you made a typo, or if you are just plain *lazy*.
-If the provided theme name contains a slash, the local theme file will be used. 
 
 
 

--- a/main.go
+++ b/main.go
@@ -88,24 +88,20 @@ func main() {
 	}
 
 	var scheme Base16Colorscheme
-	var schemeName string
 	if *schemeFlag == "" {
-		// Scheme from config
-		schemeName = appConf.Colorscheme
+	    // Scheme from config
+	    scheme = schemeList.Find(appConf.Colorscheme)
 	} else {
-		// Scheme from flag
-		schemeName = *schemeFlag
+	    // Scheme from flag
+	    scheme = schemeList.Find(*schemeFlag)
 	}
 	fmt.Println("[CONFIG]: Selected scheme: ", scheme.Name)
-	if schemeName == filepath.Base(schemeName) {
-		fmt.Println("Loading scheme from scheme list.")
-	}
 
 	templateEnabled := false
 	for app, appConfig := range appConf.Applications {
-		if appConfig.Template == "" {
-			appConfig.Template = app
-		}
+        if appConfig.Template == "" {
+            appConfig.Template = app
+        }
 		if appConfig.Enabled {
 			err := Base16Render(templateList.Find(appConfig.Template), scheme, app)
 			if err != nil {


### PR DESCRIPTION
Reverts pinpox/base16-universal-manager#56

I think I broke it. Loading normal color scheme no longer works.
Sorry for the inconvenience. I will focus on refactoring and adding tests for now.