### PR TITLE
Support templates hosted on SourceHut and GitLab (e.g. wofi) 

### DIFF
--- a/template.go
+++ b/template.go
@@ -27,6 +27,24 @@ type Base16Template struct {
 	RawBaseURL string
 }
 
+func GetRawBaseURL(repoURL string, mainBranch string) (string, error) {
+
+	parts := strings.Split(repoURL, "/")
+	rawBaseURL := ""
+	repoName := parts[3] + "/" + parts[4]
+	switch parts[2] {
+	case "git.sr.ht":
+		rawBaseURL = "https://git.sr.ht/" + repoName + "/blob/" + mainBranch + "/"
+	case "github.com":
+		rawBaseURL = "https://raw.githubusercontent.com/" + repoName + "/" + mainBranch + "/"
+	case "gitlab.com":
+		rawBaseURL = "https://gitlab.com/" + repoName + "/-/raw/" + mainBranch + "/"
+	default:
+		return "", fmt.Errorf("git host %q for %q not supported yet", parts[2], repoName)
+	}
+	return rawBaseURL, nil
+}
+
 func (l *Base16TemplateList) GetBase16Template(name string) Base16Template {
 
 	// yamlURL := "https://raw.githubusercontent.com/" + parts[3] + "/" + parts[4] + "/master/templates/config.yaml"
@@ -36,8 +54,9 @@ func (l *Base16TemplateList) GetBase16Template(name string) Base16Template {
 
 	var newTemplate Base16Template
 	newTemplate.RepoURL = l.templates[name]
-	parts := strings.Split(l.templates[name], "/")
-	newTemplate.RawBaseURL = "https://raw.githubusercontent.com/" + parts[3] + "/" + parts[4] + "/master/"
+	rawBaseURL, err := GetRawBaseURL(l.templates[name], "master")
+	check(err)
+	newTemplate.RawBaseURL = rawBaseURL
 	newTemplate.Name = name
 
 	templatePath := path.Join(appConf.TemplatesCachePath, name+".yaml")

--- a/template_test.go
+++ b/template_test.go
@@ -5,6 +5,54 @@ import (
 	"testing"
 )
 
+func TestBase16TemplateList_GetRawBaseURL(t *testing.T) {
+	type args struct {
+		url string
+		mainBranch string
+	}
+	type result struct {
+		result 	string
+		error	string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    result
+	}{
+		{
+			"sourcehut",
+			args{"https://git.sr.ht/foo/bar.git", "master"},
+			result{"https://git.sr.ht/foo/bar.git/blob/master/", ""},
+		},
+		{
+			"github",
+			args{"https://github.com/foo/bar.git", "master"},
+			result{"https://raw.githubusercontent.com/foo/bar.git/master/", ""},
+		},
+		{
+			"gitlab",
+			args{"https://gitlab.com/foo/bar.git", "master"},
+			result{"https://gitlab.com/foo/bar.git/-/raw/master/", ""},
+		},
+		{
+			"unsupported",
+			args{"https://baz.com/foo/bar.git", "master"},
+			result{"", "git host \"baz.com\" for \"foo/bar.git\" not supported yet"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetRawBaseURL(tt.args.url, tt.args.mainBranch)
+			if got != tt.want.result {
+				t.Errorf("GetRawBaseURL() result = %v, want %v", got, tt.want.result)
+			}
+			if err != nil && err.Error() != tt.want.error  {
+				t.Errorf("GetRawBaseURL() error = '%v', want '%v'", err, tt.want.error)
+			}
+		})
+	}
+}
+
 func TestBase16TemplateList_GetBase16Template(t *testing.T) {
 	type fields struct {
 		templates map[string]string


### PR DESCRIPTION
As described in the commit:

The template source from [base16-templates-source](https://github.com/chriskempson/base16-templates-source) contains a link to a
SourceHut repository (e.g. wofi) that doesn't exist on GitHub.
Only GitHub is supported at the moment by base16-universal-manager.

This is a commit with sane defaults that should work for now. But later 
we could add support for user settings to set the raw base url as well
as the main repository branch (which isn't 'master' by default in most
new repos).

### Notes
* First time I write some code in Go... Happy to hear any suggestions on doing things differently.
* Can you also update the wiki? I've pushed some changes adding `wofi` in my fork of your wiki

```bash
git clone https://github.com/pinpox/base16-universal-manager.wiki
git pull https://github.com/paul-ri/base16-universal-manager.wiki.git
git push
```

### Testing done
* Ran tests with IDE :heavy_check_mark: 
* The following config was failing, but now isn't :heavy_check_mark: 
```yaml
  wofi:
    enabled: true
    files:
      default:
        path: ~/.config/wofi/style.css
        mode: rewrite

```