### PR TITLE
Provide `@latest` tag for go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ distributions and pre-build binaries in the future.
 ### Install directly
 ```
 mkdir -p "$(go env GOPATH)/src"
-go install github.com/pinpox/base16-universal-manager
+go install github.com/pinpox/base16-universal-manager@latest
 ```
 ### Get source and build manually
 ```


### PR DESCRIPTION
While installing the manager i encountered this error:
```sh
go install github.com/pinpox/base16-universal-manager
```
```
go: 'go install' requires a version when current directory is not in a module
	Try 'go install github.com/pinpox/base16-universal-manager@latest' to install the latest version
```
Appending the relative version tag immediately resolved the issue.

P.S. Thanks so much for the awesome tooling!