### PR TITLE
Add "remote-branch" config parameter & handle scheme links failing with 404

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ out
 base16-universal-manager
 config.yaml
 testdata/output*
+
+# ---> IDEs
+# JetBrains IDEs
+.idea/

--- a/config.go
+++ b/config.go
@@ -28,10 +28,10 @@ type SetterConfig struct {
 
 // SetterAppConfig is the configuration for a particular application being themed.
 type SetterAppConfig struct {
-	Enabled     bool                  `yaml:"enabled"`
-	Hook        string                `yaml:"hook"`
-    Template    string                `yaml:"template"`
-	Files       map[string]FileConfig `yaml:"files"`
+	Enabled             bool                  `yaml:"enabled"`
+	Hook                string                `yaml:"hook"`
+	Template            string                `yaml:"template"`
+	Files               map[string]FileConfig `yaml:"files"`
 	DefaultRemoteBranch string                `yaml:"remote-branch"`
 }
 

--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ type SetterAppConfig struct {
 	Hook        string                `yaml:"hook"`
     Template    string                `yaml:"template"`
 	Files       map[string]FileConfig `yaml:"files"`
+	DefaultRemoteBranch string                `yaml:"remote-branch"`
 }
 
 // FileConfig is the configuration for how a particular file should be rendered
@@ -85,6 +86,7 @@ func (c SetterConfig) Show() {
 	for app, appConfig := range c.Applications {
 		fmt.Println("  App: ", app)
 		fmt.Println("    Enabled: ", appConfig.Enabled)
+		fmt.Println("    Default remote branch: ", appConfig.DefaultRemoteBranch)
 		fmt.Println("    Hook: ", appConfig.Hook)
 		for k, v := range appConfig.Files {
 			fmt.Println("      ", k, "  ", v)

--- a/helpers.go
+++ b/helpers.go
@@ -78,7 +78,10 @@ func findYAMLinRepo(repoURL string) []GitHubFile {
 	// Get all files from repo
 	// repoFiles, err := DownloadFileToString("https://api.github.com/repos/atelierbram/base16-atelier-schemes/contents/")
 	repoFiles, err := DownloadFileToString(ApiUrl)
-	check(err)
+	if err != nil {
+		fmt.Println("Failed to get schemes from: " + repoURL + " with error '" + err.Error() + "'")
+		return nil
+	}
 	keys := make([]GitHubFile, 0)
 	json.Unmarshal([]byte(repoFiles), &keys)
 

--- a/helpers.go
+++ b/helpers.go
@@ -18,24 +18,24 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-//DownloadFileToString downloads a file from a given URL and returns it's
-//contents as a string if successful
+// DownloadFileToString downloads a file from a given URL and returns it's
+// contents as a string if successful
 func DownloadFileToString(url string) (string, error) {
 	var client http.Client
-    req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return "", err
 	}
-    
+
 	if appConf.GithubToken != "" {
 		req.Header.Add("Authorization", "token " + appConf.GithubToken)
 	}
-	
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
-    defer resp.Body.Close()
+	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var configFile string
 
 var xdgDirs = xdg.New("base16-universal-manager", "")
 
-//Flags
+// Flags
 var (
 	updateFlag         = kingpin.Flag("update-list", "Update the list of templates and colorschemes").Bool()
 	clearListFlag      = kingpin.Flag("clear-list", "Delete local template and colorscheme list caches").Bool()
@@ -28,7 +28,7 @@ var (
 	schemeFlag         = kingpin.Flag("scheme", "Specify scheme to use (Overrides config)").String()
 )
 
-//Configuration
+// Configuration
 var appConf SetterConfig
 
 func main() {
@@ -89,19 +89,19 @@ func main() {
 
 	var scheme Base16Colorscheme
 	if *schemeFlag == "" {
-	    // Scheme from config
-	    scheme = schemeList.Find(appConf.Colorscheme)
+		// Scheme from config
+		scheme = schemeList.Find(appConf.Colorscheme)
 	} else {
-	    // Scheme from flag
-	    scheme = schemeList.Find(*schemeFlag)
+		// Scheme from flag
+		scheme = schemeList.Find(*schemeFlag)
 	}
 	fmt.Println("[CONFIG]: Selected scheme: ", scheme.Name)
 
 	templateEnabled := false
 	for app, appConfig := range appConf.Applications {
-        if appConfig.Template == "" {
-            appConfig.Template = app
-        }
+		if appConfig.Template == "" {
+			appConfig.Template = app
+		}
 		if appConfig.Enabled {
 			err := Base16Render(templateList.Find(appConfig.Template), scheme, app)
 			if err != nil {
@@ -203,7 +203,7 @@ func getSavePath(path, defaultFilename string) (string, error) {
 	return savePath, nil
 }
 
-//TODO proper error handling
+// TODO proper error handling
 func check(e error) {
 	if e != nil {
 		panic(e)

--- a/template.go
+++ b/template.go
@@ -5,8 +5,8 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
-	"strings"
 	"path"
+	"strings"
 )
 
 type Base16TemplateFile struct {

--- a/template.go
+++ b/template.go
@@ -45,7 +45,7 @@ func GetRawBaseURL(repoURL string, mainBranch string) (string, error) {
 	return rawBaseURL, nil
 }
 
-func (l *Base16TemplateList) GetBase16Template(name string) Base16Template {
+func (l *Base16TemplateList) GetBase16Template(name string, remoteBranch string) Base16Template {
 
 	// yamlURL := "https://raw.githubusercontent.com/" + parts[3] + "/" + parts[4] + "/master/templates/config.yaml"
 	if len(name) == 0 {
@@ -54,7 +54,7 @@ func (l *Base16TemplateList) GetBase16Template(name string) Base16Template {
 
 	var newTemplate Base16Template
 	newTemplate.RepoURL = l.templates[name]
-	rawBaseURL, err := GetRawBaseURL(l.templates[name], "master")
+	rawBaseURL, err := GetRawBaseURL(l.templates[name], remoteBranch)
 	check(err)
 	newTemplate.RawBaseURL = rawBaseURL
 	newTemplate.Name = name
@@ -132,5 +132,10 @@ func (c *Base16TemplateList) Find(input string) Base16Template {
 	}
 
 	templateName := FindMatchInMap(c.templates, input)
-	return c.GetBase16Template(templateName)
+	appConfig := appConf.Applications[input]
+	remoteBranch := "master"
+	if appConfig.DefaultRemoteBranch != "" {
+		remoteBranch = appConfig.DefaultRemoteBranch
+	}
+	return c.GetBase16Template(templateName, remoteBranch)
 }

--- a/template_test.go
+++ b/template_test.go
@@ -7,17 +7,17 @@ import (
 
 func TestBase16TemplateList_GetRawBaseURL(t *testing.T) {
 	type args struct {
-		url string
+		url        string
 		mainBranch string
 	}
 	type result struct {
-		result 	string
-		error	string
+		result string
+		error  string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    result
+		name string
+		args args
+		want result
 	}{
 		{
 			"sourcehut",
@@ -46,7 +46,7 @@ func TestBase16TemplateList_GetRawBaseURL(t *testing.T) {
 			if got != tt.want.result {
 				t.Errorf("GetRawBaseURL() result = %v, want %v", got, tt.want.result)
 			}
-			if err != nil && err.Error() != tt.want.error  {
+			if err != nil && err.Error() != tt.want.error {
 				t.Errorf("GetRawBaseURL() error = '%v', want '%v'", err, tt.want.error)
 			}
 		})
@@ -73,7 +73,7 @@ func TestBase16TemplateList_GetBase16Template(t *testing.T) {
 			l := &Base16TemplateList{
 				templates: tt.fields.templates,
 			}
-			if got := l.GetBase16Template(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+			if got := l.GetBase16Template(tt.args.name, "master"); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Base16TemplateList.GetBase16Template() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
* `base16-universal-manager --update-list` fails due to https://github.com/aramisgithub returning a 404 error
  * We're now printing an error message and moving on to the next color scheme
  * PR to remove links on source list at https://github.com/chriskempson/base16-schemes-source/pull/7
* Add `remote-branch` parameter to handle template repositories having a non `master` default branch. e.g. https://gitlab.com/ArenM/base16-foot is `main`
* Minor whitespace changes by the IDE 

### Testing done
* Add support for foot terminal using the new `remote-branch` parameter
```yaml
  foot:
    enabled: true
    remote-branch: "main"
    files:
      default:
        path: ~/.config/foot/foot.ini
        mode: replace
        start_marker: "^# base16 start_marker$"
        end_marker: "^# base16 end_marker$"
```
* `base16-universal-manager --update-list`
```
❯ base16-universal-manager --update-list
Found colorscheme repos:  77
Getting schemes from: https://github.com/ajlende/base16-atlas-scheme
[...]
Getting schemes from: https://github.com/Misterio77/base16-sakura-scheme
Getting schemes from: https://github.com/aramisgithub/base16-solarized-scheme
Failed to get schemes from: https://github.com/aramisgithub/base16-solarized-scheme with error 'HTTP code 404'
Getting schemes from: https://github.com/tartansandal/base16-dirtysea-scheme
Getting schemes from: https://github.com/carloabelli/base16-equilibrium-scheme
Getting schemes from: https://github.com/aramisgithub/base16-ia-scheme
Failed to get schemes from: https://github.com/aramisgithub/base16-ia-scheme with error 'HTTP code 404'
Getting schemes from: https://github.com/andreyvpng/base16-vulcan-scheme
[...]
```