### PR TITLE
Add documentation for installing through a Homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,14 @@ will never use.
 
 
 ## Installation
+I might provide packages for multiple linux distributions and pre-build
+binaries in the future.
 
-At the moment, you can only build and install this with go. You can install it
-directly or build it from source. I might provide packages for multiple linux
-distributions and pre-build binaries in the future.
-
+### Homebrew
+```
+brew tap awanwar/base16-universal-manager
+brew install --HEAD base16-universal-manager
+```
 ### Install directly
 ```
 mkdir -p "$(go env GOPATH)/src"


### PR DESCRIPTION
Created a Homebrew tap for macOS users, allowing them to install through Homebrew.

@pinpox It may be better for the tap to be maintained by you since it would be easier for you to keep the tap consistent with future updates. Feel free to copy/fork the tap repository at [awanwar/homebrew-base16-universal-manager](https://github.com/awanwar/homebrew-base16-universal-manager).