### PR TITLE
Fix and improved error handling.

### DIFF
--- a/colorscheme_test.go
+++ b/colorscheme_test.go
@@ -61,7 +61,11 @@ func TestBase16Colorscheme_MustacheContext(t *testing.T) {
 				RawBaseURL: tt.fields.RawBaseURL,
 				FileName:   tt.fields.FileName,
 			}
-			if got := s.MustacheContext(".config"); !reflect.DeepEqual(got, tt.want) {
+			got, err := s.MustacheContext(".config")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Base16Colorscheme.MustacheContext() = %v, want %v", got, tt.want)
 			}
 		})
@@ -152,7 +156,11 @@ base0F: "c33ff3"`
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewBase16Colorscheme(tt.yamlData); !reflect.DeepEqual(got, tt.want) {
+			got, err := NewBase16Colorscheme(tt.yamlData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewBase16Colorscheme() = %v, want %v", got, tt.want)
 			}
 		})
@@ -168,7 +176,11 @@ func TestLoadBase16ColorschemeList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := LoadBase16ColorschemeList(); !reflect.DeepEqual(got, tt.want) {
+			got, err := LoadBase16ColorschemeList()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LoadBase16ColorschemeList() = %v, want %v", got, tt.want)
 			}
 		})
@@ -187,7 +199,9 @@ func TestSaveBase16ColorschemeList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			SaveBase16ColorschemeList(tt.args.l)
+			if err := SaveBase16ColorschemeList(tt.args.l); err != nil {
+				t.Error(err)
+			}
 		})
 	}
 }
@@ -207,7 +221,9 @@ func TestBase16ColorschemeList_UpdateSchemes(t *testing.T) {
 			l := &Base16ColorschemeList{
 				colorschemes: tt.fields.colorschemes,
 			}
-			l.UpdateSchemes()
+			if err := l.UpdateSchemes(); err != nil {
+				t.Error(err)
+			}
 		})
 	}
 }
@@ -232,7 +248,11 @@ func TestBase16ColorschemeList_Find(t *testing.T) {
 			c := &Base16ColorschemeList{
 				colorschemes: tt.fields.colorschemes,
 			}
-			if got := c.Find(tt.args.input); !reflect.DeepEqual(got, tt.want) {
+			got, err := c.Find(tt.args.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Base16ColorschemeList.Find() = %v, want %v", got, tt.want)
 			}
 		})

--- a/config_test.go
+++ b/config_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -20,7 +19,11 @@ func TestNewConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewConfig(tt.args.path); !reflect.DeepEqual(got, tt.want) {
+			got, err := NewConfig(tt.args.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewConfig() = %v, want %v", got, tt.want)
 			}
 		})
@@ -67,7 +70,7 @@ func TestSetterConfig_Show(t *testing.T) {
 
 func TestDefaultMasterURLs(t *testing.T) {
 	// Create a temporary, empty config file
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "base16-universal-manager-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "base16-universal-manager-")
 	if err != nil {
 		t.Fatalf("Cannot create temporary file\n")
 	}
@@ -76,7 +79,10 @@ func TestDefaultMasterURLs(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
-	config := NewConfig(tmpFile.Name())
+	config, err := NewConfig(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if config.SchemesMasterURL == "" {
 		t.Fatalf("SchemesMasterURL should default to %s\n", defaultSchemesMasterURL)
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -125,18 +125,30 @@ func FindMatchInMap(choices map[string]string, input string) (string, error) {
 	if len(choices) == 0 {
 		return "", errors.New("cannot select from empty choices")
 	}
-	var match string
-	distance := 1000
+	var matches []string
+	var distance int
 
 	for k := range choices {
 		tempDistance := levenshtein.ComputeDistance(input, k)
-		if tempDistance < distance {
-			match = k
+		if tempDistance < distance || len(matches) == 0 {
 			distance = tempDistance
+			matches = nil
+			matches = append(matches, k)
+		} else if tempDistance == distance {
+			matches = append(matches, k)
 		}
 	}
 
-	return match, nil
+	if len(matches) != 1 {
+		return "", fmt.Errorf(
+			"found %d matches to %q with same similarity score, consider specifying a closer match to a candidate - candidates are: %v",
+			len(matches),
+			input,
+			strings.Join(matches, ", "),
+		)
+	}
+
+	return matches[0], nil
 }
 
 func exe_cmd(cmd string) {

--- a/helpers.go
+++ b/helpers.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"encoding/json"
-
 	"bufio"
 	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -28,7 +28,7 @@ func DownloadFileToString(url string) (string, error) {
 	}
 
 	if appConf.GithubToken != "" {
-		req.Header.Add("Authorization", "token " + appConf.GithubToken)
+		req.Header.Add("Authorization", "token "+appConf.GithubToken)
 	}
 
 	resp, err := client.Do(req)
@@ -37,7 +37,7 @@ func DownloadFileToString(url string) (string, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", err
 		}
@@ -70,7 +70,6 @@ type GitHubFilesCollection struct {
 }
 
 func findYAMLinRepo(repoURL string) []GitHubFile {
-
 	parts := strings.Split(repoURL, "/")
 	ApiUrl := ("https://api.github.com/repos/" + parts[3] + "/" + parts[4] + "/contents/")
 	// fmt.Println("generated api URL: ", ApiUrl)
@@ -98,34 +97,33 @@ func findYAMLinRepo(repoURL string) []GitHubFile {
 	return colorSchemes
 }
 
-func LoadStringMap(path string) map[string]string {
-
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
-	check(err)
-	yamlFile, err := ioutil.ReadAll(f)
-	check(err)
+func LoadStringMap(path string) (map[string]string, error) {
+	yamlFile, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading from file %s: %w", path, err)
+	}
 	data := make(map[string]string)
-	err = yaml.Unmarshal(yamlFile, data)
-	check(err)
-	return data
+	if err := yaml.Unmarshal(yamlFile, data); err != nil {
+		return nil, fmt.Errorf("parsing YAML from file %s: %w", path, err)
+	}
+	return data, nil
 }
 
-func SaveStringMap(data map[string]string, path string) {
-
+func SaveStringMap(data map[string]string, path string) error {
 	yamlData, err := yaml.Marshal(data)
-	check(err)
-	saveFile, err := os.Create(path)
-	defer saveFile.Close()
-	saveFile.Write(yamlData)
-	saveFile.Close()
-	fmt.Println("wrote to: ", saveFile.Name())
+	if err != nil {
+		return fmt.Errorf("marshaling to YAML: %w", err)
+	}
+	if err := os.WriteFile(path, yamlData, os.ModePerm); err != nil {
+		return fmt.Errorf("writing YAML: %w", err)
+	}
+	fmt.Println("wrote to: ", path)
+	return nil
 }
 
-func FindMatchInMap(choices map[string]string, input string) string {
-
+func FindMatchInMap(choices map[string]string, input string) (string, error) {
 	if len(choices) == 0 {
-		panic("cannot select from empty choices")
-
+		return "", errors.New("cannot select from empty choices")
 	}
 	var match string
 	distance := 1000
@@ -138,17 +136,16 @@ func FindMatchInMap(choices map[string]string, input string) string {
 		}
 	}
 
-	return match
+	return match, nil
 }
 
 func exe_cmd(cmd string) {
-
 	if len(cmd) == 0 {
 		return
 	}
 	parts := strings.Fields(cmd)
 	head := parts[0]
-	parts = parts[1:len(parts)]
+	parts = parts[1:]
 
 	out, err := exec.Command(head, parts...).Output()
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -66,7 +66,11 @@ func TestLoadStringMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := LoadStringMap(tt.args.path); !reflect.DeepEqual(got, tt.want) {
+			got, err := LoadStringMap(tt.args.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LoadStringMap() = %v, want %v", got, tt.want)
 			}
 		})
@@ -86,7 +90,9 @@ func TestSaveStringMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			SaveStringMap(tt.args.data, tt.args.path)
+			if err := SaveStringMap(tt.args.data, tt.args.path); err != nil {
+				t.Error(err)
+			}
 		})
 	}
 }
@@ -105,7 +111,11 @@ func TestFindMatchInMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FindMatchInMap(tt.args.choices, tt.args.input); got != tt.want {
+			got, err := FindMatchInMap(tt.args.choices, tt.args.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
 				t.Errorf("FindMatchInMap() = %v, want %v", got, tt.want)
 			}
 		})
@@ -176,8 +186,7 @@ func TestWriteFile(t *testing.T) {
 }
 
 func TestReplaceMultiline(t *testing.T) {
-	type args struct {
-	}
+	type args struct{}
 	tests := []struct {
 		name        string
 		path        string

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ func TestBase16Render(t *testing.T) {
 	type args struct {
 		templ  Base16Template
 		scheme Base16Colorscheme
-		app string
+		app    string
 	}
 	tests := []struct {
 		name string
@@ -32,23 +32,6 @@ func TestBase16Render(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			Base16Render(tt.args.templ, tt.args.scheme, tt.args.app)
-		})
-	}
-}
-
-func Test_check(t *testing.T) {
-	type args struct {
-		e error
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			check(tt.args.e)
 		})
 	}
 }

--- a/template_test.go
+++ b/template_test.go
@@ -73,7 +73,11 @@ func TestBase16TemplateList_GetBase16Template(t *testing.T) {
 			l := &Base16TemplateList{
 				templates: tt.fields.templates,
 			}
-			if got := l.GetBase16Template(tt.args.name, "master"); !reflect.DeepEqual(got, tt.want) {
+			got, err := l.GetBase16Template(tt.args.name, "master")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Base16TemplateList.GetBase16Template() = %v, want %v", got, tt.want)
 			}
 		})
@@ -109,7 +113,11 @@ func TestLoadBase16TemplateList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := LoadBase16TemplateList(); !reflect.DeepEqual(got, tt.want) {
+			got, err := LoadBase16TemplateList()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LoadBase16TemplateList() = %v, want %v", got, tt.want)
 			}
 		})
@@ -128,7 +136,9 @@ func TestSaveBase16TemplateList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			SaveBase16TemplateList(tt.args.l)
+			if err := SaveBase16TemplateList(tt.args.l); err != nil {
+				t.Error(err)
+			}
 		})
 	}
 }
@@ -153,7 +163,11 @@ func TestBase16TemplateList_Find(t *testing.T) {
 			c := &Base16TemplateList{
 				templates: tt.fields.templates,
 			}
-			if got := c.Find(tt.args.input); !reflect.DeepEqual(got, tt.want) {
+			got, err := c.Find(tt.args.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Base16TemplateList.Find() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
* Remove all use of `panic()`. Fixes #9 .
* Remove use of deprecated `io/ioutil`.
* Fix ambiguity bug when matching templates/schemes that led to unstable match results. The program will output an error explaining the problem rather than picking an unstable result.
